### PR TITLE
docs(config): mark external-secrets.io/v1beta1 removed in ESO v0.17.0…

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Warns about usage of deprecated API versions across Kubernetes and common operat
 - Kubernetes betas removed in 1.22/1.25/1.26 (Ingress, PDB, EndpointSlice, FlowControl, etc.)
 - Flux Toolkit legacy APIs (v1alpha1/v1beta1) — deprecated; exact removals pending upstream confirmations
 - External Secrets Operator `v1alpha1`/`v1beta1` — deprecated; exact removals pending
+- External Secrets Operator `v1beta1` — removed in ESO v0.17.0; `v1alpha1` deprecated
 - Flagger `flagger.app` v1alpha3/v1beta1 — deprecated; exact removals pending
 - Argo CD `argoproj.io` v1alpha1/v1beta1 — deprecated; exact removals pending per CRD
 - cert-manager `cert-manager.io` v1alpha2/v1alpha3 — deprecated; exact removals pending

--- a/data/gitops-validator.yaml
+++ b/data/gitops-validator.yaml
@@ -145,7 +145,7 @@ gitops-validator:
         severity: "warning"
         operator_category: "external-secrets"
       - api_version: "external-secrets.io/v1beta1"
-        deprecation_info: "Deprecated; exact removal version unknown (pending official confirmation)"
+        deprecation_info: "Deprecated; removed in External Secrets Operator v0.17.0"
         severity: "warning"
         operator_category: "external-secrets"
       # Flagger APIs

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -20,7 +20,7 @@ var (
 )
 
 var (
-	version = "1.0.10"
+	version = "1.0.11"
 	commit  = "main"
 	date    = "2025-09-16"
 )


### PR DESCRIPTION
…; README note; bump to 1.0.11