### PR TITLE
feat: Add Flux postBuild variable naming validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A comprehensive validation tool for GitOps repositories that checks for common i
 ## Features
 
 - **Flux Kustomization Validation**: Validates Flux Kustomization resources for broken path and source references (paths must be relative to repository root)
+- **Flux PostBuild Variables Validation**: Validates Flux postBuild substitute variable naming (no dashes allowed, must match pattern `^[_a-zA-Z][_a-zA-Z0-9]*$`)
 - **Kubernetes Kustomization Validation**: Validates kustomization.yaml files for broken resource and patch references (paths relative to kustomization file)
 - **Orphaned Resource Detection**: Identifies YAML files that are not referenced by any kustomization
 - **Deprecated API Detection**: Warns about usage of deprecated Kubernetes API versions
@@ -204,6 +205,9 @@ rules:
   flux-kustomization:
     enabled: true
     severity: "error"
+  flux-postbuild-variables:
+    enabled: true
+    severity: "error"
   kubernetes-kustomization:
     enabled: true
     severity: "error"
@@ -299,6 +303,24 @@ Validates Flux Kustomization resources for:
 - Missing or invalid `path` references
 - Missing or invalid `sourceRef.name` references
 - Broken file system paths
+
+### Flux PostBuild Variables Validation
+
+Validates Flux Kustomization `postBuild.substitute` variable naming:
+- Variable names must start with underscore (`_`) or letter (`a-z`, `A-Z`)
+- Variable names can only contain letters, digits, and underscores
+- **Dashes are NOT allowed** (common mistake from Kubernetes naming conventions)
+- Pattern: `^[_a-zA-Z][_a-zA-Z0-9]*$`
+
+**Valid examples:**
+- `${CLUSTER_NAME}`
+- `${_private_var}`
+- `${env_123}`
+
+**Invalid examples:**
+- `${cluster-name}` ❌ (contains dash)
+- `${123var}` ❌ (starts with digit)
+- `${my.var}` ❌ (contains dot)
 
 ### Kubernetes Kustomization Validation
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,28 @@
 # Release Notes
 
+## Version 1.1.5 (2025-10-08)
+
+### New Features
+- **Flux PostBuild Variables Validation**: Added new validator for Flux Kustomization `postBuild.substitute` variable naming
+  - Enforces Flux variable naming rules: must start with underscore or letter, followed by letters, digits, or underscores only
+  - Catches common mistakes like using dashes (Kubernetes naming convention) in Flux variables
+  - Pattern: `^[_a-zA-Z][_a-zA-Z0-9]*$`
+  - Helps prevent runtime errors from invalid variable names
+
+### Configuration
+- Added `flux-postbuild-variables` rule to configuration (enabled by default with error severity)
+- Updated example configurations to include the new validation rule
+
+### Documentation
+- Added detailed Flux PostBuild Variables validation section to README
+- Included valid/invalid variable name examples
+- Added test examples demonstrating correct and incorrect variable usage
+
+### Upgrade
+Binary and bundle available on Releases. The new validator is enabled by default and will catch invalid Flux variable names in your `postBuild.substitute` sections.
+
+---
+
 ## Version 1.1.4 (2025-09-18)
 
 - removed several Flux apis from warning

--- a/data/gitops-validator.yaml
+++ b/data/gitops-validator.yaml
@@ -17,6 +17,11 @@ gitops-validator:
     flux-kustomization:
       enabled: true
       severity: "error"
+    
+    # Flux PostBuild Variables validation
+    flux-postbuild-variables:
+      enabled: true
+      severity: "error"
       
     # Kubernetes Kustomization validation  
     kubernetes-kustomization:

--- a/examples/flux-postbuild-test.yaml
+++ b/examples/flux-postbuild-test.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: valid-variables-example
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./clusters/production
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  postBuild:
+    substitute:
+      # Valid variable names
+      CLUSTER_NAME: "production"
+      ENV: "prod"
+      _private_var: "secret"
+      region123: "us-east-1"
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: invalid-variables-example
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./clusters/staging
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  postBuild:
+    substitute:
+      # Invalid variable names (will be caught by validator)
+      # cluster-name: "staging"        # ERROR: contains dash
+      # my-env-var: "staging"          # ERROR: contains dashes
+      # region.name: "us-west-1"       # ERROR: contains dot (if tested)
+

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -20,9 +20,9 @@ var (
 )
 
 var (
-	version = "1.1.4"
+	version = "1.1.5"
 	commit  = "main"
-	date    = "2025-09-18"
+	date    = "2025-10-08"
 )
 
 var rootCmd = &cobra.Command{
@@ -30,6 +30,7 @@ var rootCmd = &cobra.Command{
 	Short: "Validate GitOps repositories for Flux and Kubernetes",
 	Long: `A comprehensive validation tool for GitOps repositories that checks for:
 - Flux Kustomization link integrity
+- Flux postBuild variable naming (no dashes allowed)
 - Kubernetes Kustomization link integrity  
 - Orphaned resources not referenced by any Kustomization
 - Deprecated Kubernetes API versions

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,7 @@ type EntryPointsConfig struct {
 // RulesConfig defines which validation rules to run
 type RulesConfig struct {
 	FluxKustomization       RuleConfig `yaml:"flux-kustomization"`
+	FluxPostBuildVariables  RuleConfig `yaml:"flux-postbuild-variables"`
 	KubernetesKustomization RuleConfig `yaml:"kubernetes-kustomization"`
 	OrphanedResources       RuleConfig `yaml:"orphaned-resources"`
 	DeprecatedAPIs          RuleConfig `yaml:"deprecated-apis"`
@@ -119,6 +120,7 @@ func DefaultConfig() *Config {
 			},
 			Rules: RulesConfig{
 				FluxKustomization:       RuleConfig{Enabled: true, Severity: "error"},
+				FluxPostBuildVariables:  RuleConfig{Enabled: true, Severity: "error"},
 				KubernetesKustomization: RuleConfig{Enabled: true, Severity: "error"},
 				OrphanedResources:       RuleConfig{Enabled: true, Severity: "warning"},
 				DeprecatedAPIs:          RuleConfig{Enabled: true, Severity: "warning"},
@@ -259,6 +261,7 @@ func (c *Config) Validate() error {
 	// Validate rule severities
 	rules := []RuleConfig{
 		c.GitOpsValidator.Rules.FluxKustomization,
+		c.GitOpsValidator.Rules.FluxPostBuildVariables,
 		c.GitOpsValidator.Rules.KubernetesKustomization,
 		c.GitOpsValidator.Rules.OrphanedResources,
 		c.GitOpsValidator.Rules.DeprecatedAPIs,
@@ -300,6 +303,8 @@ func (c *Config) IsRuleEnabled(ruleName string) bool {
 	switch ruleName {
 	case "flux-kustomization":
 		return c.GitOpsValidator.Rules.FluxKustomization.Enabled
+	case "flux-postbuild-variables":
+		return c.GitOpsValidator.Rules.FluxPostBuildVariables.Enabled
 	case "kubernetes-kustomization":
 		return c.GitOpsValidator.Rules.KubernetesKustomization.Enabled
 	case "orphaned-resources":
@@ -320,6 +325,8 @@ func (c *Config) GetRuleSeverity(ruleName string) string {
 	switch ruleName {
 	case "flux-kustomization":
 		return c.GitOpsValidator.Rules.FluxKustomization.Severity
+	case "flux-postbuild-variables":
+		return c.GitOpsValidator.Rules.FluxPostBuildVariables.Severity
 	case "kubernetes-kustomization":
 		return c.GitOpsValidator.Rules.KubernetesKustomization.Severity
 	case "orphaned-resources":

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -108,6 +108,7 @@ func (v *Validator) Validate() (int, error) {
 		validators.NewKubernetesKustomizationValidator(v.repoPath),
 		validators.NewOrphanedResourceValidatorWithConfig(v.repoPath, v.config),
 		deprecatedAPIValidator,
+		validators.NewFluxPostBuildVariablesValidator(v.repoPath),
 	}
 
 	// Run all validators

--- a/internal/validators/flux_postbuild_variables.go
+++ b/internal/validators/flux_postbuild_variables.go
@@ -1,0 +1,215 @@
+package validators
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/moon-hex/gitops-validator/internal/types"
+
+	"gopkg.in/yaml.v3"
+)
+
+type FluxPostBuildVariablesValidator struct {
+	repoPath string
+}
+
+func NewFluxPostBuildVariablesValidator(repoPath string) *FluxPostBuildVariablesValidator {
+	return &FluxPostBuildVariablesValidator{
+		repoPath: repoPath,
+	}
+}
+
+func (v *FluxPostBuildVariablesValidator) Name() string {
+	return "Flux PostBuild Variables Validator"
+}
+
+// Flux variable naming pattern: must start with _ or letter, followed by letters, digits, or underscores
+// Pattern: ^[_[:alpha:]][_[:alpha:][:digit:]]*$
+var fluxVariableNamePattern = regexp.MustCompile(`^[_a-zA-Z][_a-zA-Z0-9]*$`)
+
+func (v *FluxPostBuildVariablesValidator) Validate() ([]types.ValidationResult, error) {
+	var results []types.ValidationResult
+
+	// Find all Flux Kustomization resources
+	kustomizations, err := v.findFluxKustomizations()
+	if err != nil {
+		return results, fmt.Errorf("failed to find Flux Kustomizations: %w", err)
+	}
+
+	for _, kustomization := range kustomizations {
+		// Validate postBuild substitute variable names
+		for _, variable := range kustomization.PostBuildVariables {
+			if !fluxVariableNamePattern.MatchString(variable.Name) {
+				results = append(results, types.ValidationResult{
+					Type:     "flux-postbuild-variables",
+					Severity: "error",
+					Message: fmt.Sprintf("Invalid Flux variable name '%s': must start with underscore or letter, followed by letters, digits, or underscores only (no dashes allowed). Pattern: ^[_a-zA-Z][_a-zA-Z0-9]*$",
+						variable.Name),
+					File:     kustomization.File,
+					Line:     variable.Line,
+					Resource: kustomization.Name,
+				})
+			}
+		}
+	}
+
+	return results, nil
+}
+
+type FluxKustomizationWithPostBuild struct {
+	File               string
+	Name               string
+	PostBuildVariables []VariableInfo
+}
+
+type VariableInfo struct {
+	Name string
+	Line int
+}
+
+func (v *FluxPostBuildVariablesValidator) findFluxKustomizations() ([]FluxKustomizationWithPostBuild, error) {
+	var kustomizations []FluxKustomizationWithPostBuild
+
+	err := filepath.Walk(v.repoPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if !strings.HasSuffix(strings.ToLower(path), ".yaml") && !strings.HasSuffix(strings.ToLower(path), ".yml") {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		decoder := yaml.NewDecoder(file)
+		var doc yaml.Node
+
+		for {
+			err := decoder.Decode(&doc)
+			if err != nil {
+				break
+			}
+
+			if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+				resource := doc.Content[0]
+				if v.isFluxKustomization(resource) {
+					kustomization := v.extractPostBuildVariables(resource, path)
+					if kustomization != nil {
+						kustomizations = append(kustomizations, *kustomization)
+					}
+				}
+			}
+		}
+
+		return nil
+	})
+
+	return kustomizations, err
+}
+
+func (v *FluxPostBuildVariablesValidator) isFluxKustomization(node *yaml.Node) bool {
+	if node.Kind != yaml.MappingNode {
+		return false
+	}
+
+	var kind, apiVersion string
+
+	for i := 0; i < len(node.Content); i += 2 {
+		key := node.Content[i]
+		value := node.Content[i+1]
+
+		if key.Value == "kind" && value.Value == "Kustomization" {
+			kind = value.Value
+		}
+
+		if key.Value == "apiVersion" && strings.HasPrefix(value.Value, "kustomize.toolkit.fluxcd.io/") {
+			apiVersion = value.Value
+		}
+	}
+
+	return kind == "Kustomization" && apiVersion != ""
+}
+
+func (v *FluxPostBuildVariablesValidator) extractPostBuildVariables(node *yaml.Node, filePath string) *FluxKustomizationWithPostBuild {
+	var name string
+	var variables []VariableInfo
+
+	for i := 0; i < len(node.Content); i += 2 {
+		key := node.Content[i]
+		value := node.Content[i+1]
+
+		switch key.Value {
+		case "metadata":
+			if value.Kind == yaml.MappingNode {
+				for j := 0; j < len(value.Content); j += 2 {
+					if value.Content[j].Value == "name" {
+						name = value.Content[j+1].Value
+					}
+				}
+			}
+		case "spec":
+			if value.Kind == yaml.MappingNode {
+				for j := 0; j < len(value.Content); j += 2 {
+					if value.Content[j].Value == "postBuild" {
+						variables = v.extractVariablesFromPostBuild(value.Content[j+1])
+					}
+				}
+			}
+		}
+	}
+
+	if name == "" {
+		return nil
+	}
+
+	// Only return if there are variables to validate
+	if len(variables) == 0 {
+		return nil
+	}
+
+	return &FluxKustomizationWithPostBuild{
+		File:               filePath,
+		Name:               name,
+		PostBuildVariables: variables,
+	}
+}
+
+func (v *FluxPostBuildVariablesValidator) extractVariablesFromPostBuild(postBuildNode *yaml.Node) []VariableInfo {
+	var variables []VariableInfo
+
+	if postBuildNode.Kind != yaml.MappingNode {
+		return variables
+	}
+
+	for i := 0; i < len(postBuildNode.Content); i += 2 {
+		key := postBuildNode.Content[i]
+		value := postBuildNode.Content[i+1]
+
+		if key.Value == "substitute" {
+			// substitute is a map of variable names to values
+			if value.Kind == yaml.MappingNode {
+				for j := 0; j < len(value.Content); j += 2 {
+					varName := value.Content[j].Value
+					varLine := value.Content[j].Line
+					variables = append(variables, VariableInfo{
+						Name: varName,
+						Line: varLine,
+					})
+				}
+			}
+		}
+	}
+
+	return variables
+}


### PR DESCRIPTION
- Add new validator for Flux Kustomization postBuild.substitute variable names
- Enforce Flux variable naming rules: ^[_a-zA-Z][_a-zA-Z0-9]*$
- Catches common mistakes like using dashes (Kubernetes naming) in Flux variables
- Add configuration support for flux-postbuild-variables rule
- Update README with detailed validation examples
- Add test examples demonstrating valid/invalid variable names
- Bump version to 1.1.5